### PR TITLE
Fix broken link to SteamKit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Steam for Node.js
 
-This is a Node.js port of [SteamKit2](https://bitbucket.org/VoiDeD/steamre/wiki/Home). It lets you interface with Steam without running an actual Steam client. Could be used to run an autonomous chat/trade bot.
+This is a Node.js port of [SteamKit2](https://github.com/SteamRE/SteamKit). It lets you interface with Steam without running an actual Steam client. Could be used to run an autonomous chat/trade bot.
 
 
 # Installation


### PR DESCRIPTION
SteamKit2 moved to GitHub and now lives at [SteamRE/SteamKit](https://github.com/SteamRE/SteamKit).
