### PR TITLE
Save and use the full sentry file

### DIFF
--- a/lib/handlers/user.js
+++ b/lib/handlers/user.js
@@ -21,6 +21,12 @@ prototype.logOn = function(logOnDetails) {
   this._jobs = {};
   this._currentJobID = 0;
   
+  if(logOnDetails.shaSentryfile && logOnDetails.shaSentryfile.length > 20) {
+    var sha = require('crypto').createHash('sha1');
+    sha.update(logOnDetails.shaSentryfile);
+    logOnDetails.shaSentryfile = new Buffer(sha.digest(), 'binary');
+  }
+  
   // construct temporary SteamID
   this.steamID = new (require('../steamID'))({
     accountInstance: 1,
@@ -222,14 +228,16 @@ handlers[EMsg.ClientLoggedOff] = function(data) {
 };
 
 handlers[EMsg.ClientUpdateMachineAuth] = function(data, jobID) {
+  var sentryfile = schema.CMsgClientUpdateMachineAuth.decode(data).bytes.toBuffer();
+  
   var sha = require('crypto').createHash('sha1');
-  sha.update(schema.CMsgClientUpdateMachineAuth.decode(data).bytes.toBuffer());
+  sha.update(sentryfile);
   sha = new Buffer(sha.digest(), 'binary');
   
   this._send(EMsg.ClientUpdateMachineAuthResponse | protoMask, new schema.CMsgClientUpdateMachineAuthResponse({
     shaFile: sha
   }), jobID);
-  this.emit('sentry', sha);
+  this.emit('sentry', sentryfile);
 };
 
 handlers[EMsg.ClientUserNotifications] = function(data) {


### PR DESCRIPTION
Existing bots with just the hashes saved will continue to work fine, and bots getting new sentryfiles will save the entire thing.

In the event that Steam actually starts using the CMsgClientUpdateMachineAuth msgs, this won't cause (as much) mass-headache.