### PR TITLE
Added support for ClientFriendMsgEchoToSender

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ Some activity in your group list. For example, `EClanRelationship.Invited` means
 ### 'message'
 Same arguments as the above two, captures both events. In case of a friend message, the fourth argument will be undefined.
 
+### 'friendMsgEchoToSender'
+Same as '[friendMsg](#friendmsg)', except it is a message you send to a friend on another client.
+
 ### 'chatEnter'
 * SteamID of the chat room
 * `EChatRoomEnterResponse`

--- a/lib/handlers/friends.js
+++ b/lib/handlers/friends.js
@@ -251,6 +251,15 @@ handlers[EMsg.ClientFriendMsgIncoming] = function(data) {
   this.emit('friendMsg', friendMsg.steamidFrom.toString(), message, friendMsg.chatEntryType);
 };
 
+handlers[EMsg.ClientFriendMsgEchoToSender] = function(data) {
+  var friendMsg = schema.CMsgClientFriendMsgIncoming.decode(data);
+  
+  // Steam cuts off after the first null
+  var message = friendMsg.message.toString('utf8').split('\u0000')[0];
+  
+  this.emit('friendMsgEchoToSender', friendMsg.steamidFrom.toString(), message, friendMsg.chatEntryType);
+}
+
 handlers[EMsg.ClientChatMsg] = function(data) {
   var chatMsg = schema.MsgClientChatMsg.decode(data);
   


### PR DESCRIPTION
Client will now be notified of messages you send to a friend on another client.

I basically just ported `HandleFriendEchoMsg` from https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs

Now it is only emitting 'friendMsgEchoToSender'. If we want to emit 'message' also we'd need to figure out the callback args as it is identical to that of friendMsg.