### PR TITLE
Call toBuffer() on the EMsg before sending it

### DIFF
--- a/lib/handlers/user/index.js
+++ b/lib/handlers/user/index.js
@@ -37,7 +37,7 @@ SteamUser.prototype.requestWebAPIAuthenticateUserNonce = function(callback) {
   this._client.send({
     msg: EMsg.ClientRequestWebAPIAuthenticateUserNonce,
     proto: {}
-  }, new schema.CMsgClientRequestWebAPIAuthenticateUserNonce(), function(header, body) {
+  }, new schema.CMsgClientRequestWebAPIAuthenticateUserNonce().toBuffer(), function(header, body) {
     var nonce = schema.CMsgClientRequestWebAPIAuthenticateUserNonceResponse.decode(body);
     callback(Steam._processProto(nonce));
   });


### PR DESCRIPTION
All other `EMsg` objects sent to `_client` require bufferising. This hadn't been which caused an error when calling this method.