### PR TITLE
Fixed non-protobuf GC messages not sending

### DIFF
--- a/lib/handlers/game_coordinator/index.js
+++ b/lib/handlers/game_coordinator/index.js
@@ -36,6 +36,8 @@ SteamGameCoordinator.prototype._send = function(header, body, callback) {
     this._jobs[sourceJobID] = callback;
   }
   
+  var type = header.msg;
+  
   if (header.proto) {
     header.proto.job_id_source = sourceJobID;
     header = new schema.MsgGCHdrProtoBuf(header);
@@ -50,7 +52,7 @@ SteamGameCoordinator.prototype._send = function(header, body, callback) {
       routing_appid: this._appid
     }
   }, new schema.CMsgGCClient({
-    msgtype: header.proto ? header.msg | protoMask : header.msg,
+    msgtype: header.proto ? type | protoMask : type,
     appid: this._appid,
     payload: Buffer.concat([header.toBuffer(), body])
   }).toBuffer());


### PR DESCRIPTION
[`MsgGCHdr`](https://github.com/SteamRE/SteamKit/blob/master/Resources/SteamLanguage/gamecoordinator.steamd#L11-L17) doesn't have a `msg` field. Therefore, when you create the `MsgGCHdr` object, the `msg` field is dropped and no `msgtype` is sent to Steam.

Tested and works. Reported to me in DoctorMcKay/node-tf2#9.