### PR TITLE
fix(web-api-nonce): crash caused by authing with web api

### DIFF
--- a/lib/handlers/user/index.js
+++ b/lib/handlers/user/index.js
@@ -38,6 +38,10 @@ SteamUser.prototype.requestWebAPIAuthenticateUserNonce = function(callback) {
     msg: EMsg.ClientRequestWebAPIAuthenticateUserNonce,
     proto: {}
   }, new schema.CMsgClientRequestWebAPIAuthenticateUserNonce().toBuffer(), function(header, body) {
+    if (header.msg == EMsg.DestJobFailed) {
+      return;
+    }
+    
     var nonce = schema.CMsgClientRequestWebAPIAuthenticateUserNonceResponse.decode(body);
     callback(Steam._processProto(nonce));
   });


### PR DESCRIPTION
Resolves #234

This error is thrown when a callback calls [#requestWebAPIAuthenticateUserNonce](https://github.com/seishun/node-steam/blob/master/lib/handlers/user/index.js#L36), after the client as been disconnected from steam.

This message requires both `steamID` and `sessionID` to be set, but when the client is disconnected they are both unset, causing this header to be sent:
```
{ msg: 5585,
  proto:
   { client_sessionid: 0,
     steamid: '76561197960265728',
     jobid_source: 1 } }
```
(`76561197960265728` is the base steamID, generated [here](https://github.com/seishun/node-steam/blob/master/lib/handlers/user/index.js#L23-L27))

This causes this header to be received with no body.
```
{ msg: 113,
  headerSize: 36,
  headerVersion: 2,
  targetJobID: { low: 1, high: 0, unsigned: true },
  sourceJobID: { low: -1, high: -1, unsigned: true },
  headerCanary: -17,
  steamID: { low: 0, high: 0, unsigned: true }
```

Which is just the default destination job failed header.

Obviously this will make whatever callback the user passes to be never called, but any code that would be calling this method should be happening after the `logOnResponse` event is fired, so it will be retriggered once the client is logged back in.

### Reproduction 
Reproducing this is tricky, as it's all timing. However, a way to cause this to happen is start a client that calls #requestWebAPIAuthenticateUserNonce, then start another client with the same steamID. This will disconnect the first client, allowing this error to be reproduced.