### PR TITLE
Support GZipped MsgMulti messages

### DIFF
--- a/lib/steam_client.js
+++ b/lib/steam_client.js
@@ -21,6 +21,8 @@ var EMsg = Steam.EMsg;
 
 var protoMask = 0x80000000;
 
+const ZIP_SIGNATURE = 0x04034B50;
+const GZIP_SIGNATURE = 0x00088B1F;
 
 function SteamClient() {
   EventEmitter.call(this);
@@ -250,7 +252,16 @@ handlers[EMsg.Multi] = function(data) {
   var payload = msgMulti.message_body.toBuffer();
       
   if (msgMulti.size_unzipped) {
-    payload = zlib.gunzipSync(payload);
+    var sig = payload.readUInt32LE(0);
+
+    if (sig == ZIP_SIGNATURE) {
+      payload = zlib.inflateRawSync(payload.slice(31)); // 31 = 30 (zip header size) + 1 (file name length)
+    } else if ((sig & 0x00FFFFFF) == GZIP_SIGNATURE) {
+      payload = zlib.gunzipSync(payload);
+    } else {
+      this.emit('error', new Error('MsgMulti: unknown compression type'));
+      return;
+    }
   }
   
   // stop handling if user disconnected

--- a/lib/steam_client.js
+++ b/lib/steam_client.js
@@ -1,6 +1,7 @@
 var ByteBuffer = require('bytebuffer');
 var EventEmitter = require('events').EventEmitter;
 var Steam = module.exports = require('steam-resources');
+var zlib = require('zlib');
 
 var schema = Steam.Internal;
 
@@ -249,8 +250,7 @@ handlers[EMsg.Multi] = function(data) {
   var payload = msgMulti.message_body.toBuffer();
       
   if (msgMulti.size_unzipped) {
-    var zip = new (require('adm-zip'))(payload);
-    payload = zip.readFile('z');
+    payload = zlib.gunzipSync(payload);
   }
   
   // stop handling if user disconnected

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/seishun/node-steam.git"
   },
   "dependencies": {
-    "adm-zip": "^0.4",
     "buffer-crc32": "^0.2",
     "bytebuffer": "^5.0",
     "steam-crypto": "^0.0",


### PR DESCRIPTION
Since Steam using gzip, adm-zip was useless.
Now we can use the latest version of the protocol (65579 or better MsgClientLogon.CurrentProtocol).
I'm testing it for over a month, and everything works fine :)
