### PR TITLE
Fix file's name, use `fs.writeFileSync`

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,9 +1,11 @@
 var fs = require('fs');
-var Steam = require('steam');
+var Steam = require('./');
+
+var serversFile = './serverList.json';
 
 // if we've saved a server list, use it
-if (fs.existsSync('servers')) {
-  Steam.servers = JSON.parse(fs.readFileSync('servers'));
+if (fs.existsSync(serversFile)) {
+  Steam.servers = JSON.parse(fs.readFileSync(serversFile));
 }
 
 var steamClient = new Steam.SteamClient();
@@ -28,7 +30,7 @@ steamClient.on('logOnResponse', function(logonResp) {
 });
 
 steamClient.on('servers', function(servers) {
-  fs.writeFile('servers', JSON.stringify(servers));
+  fs.writeFileSync(serversFile, JSON.stringify(servers));
 });
 
 steamFriends.on('chatInvite', function(chatRoomID, chatRoomName, patronID) {


### PR DESCRIPTION
- Change `require('steam')` to `require('./')`, easy to call in local.
- If you save file named: `servers`, [`require('../servers')`](https://github.com/seishun/node-steam/blob/8f0f68bc24/lib/steam_client.js#L33) will call your file server was saved, not `server.json`, you can change it to `require('../servers,json')`.
- `fs.writeFile` need callback, you can use `fs.writeFileSync` or add callback.