### PR TITLE
Use  'Buffer.alloc(size)' instead of 'new Buffer(size)'

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -17,7 +17,7 @@ Connection.prototype.send = function(data) {
     data = require('steam-crypto').symmetricEncrypt(data, this.sessionKey);
   }
   
-  var buffer = new Buffer(4 + 4 + data.length);
+  var buffer = Buffer.alloc(4 + 4 + data.length);
   buffer.writeUInt32LE(data.length, 0);
   buffer.write(MAGIC, 4);
   data.copy(buffer, 8);

--- a/lib/steam_client.js
+++ b/lib/steam_client.js
@@ -296,7 +296,7 @@ handlers[EMsg.ClientLoggedOff] = function(data) {
 handlers[EMsg.ClientCMList] = function(data) {
   var list = schema.CMsgClientCMList.decode(data);
   var servers = list.cm_addresses.map(function(number, index) {
-    var buf = new Buffer(4);
+    var buf = Buffer.alloc(4);
     buf.writeUInt32BE(number, 0);
     return {
       host: [].join.call(buf, '.'),


### PR DESCRIPTION
Buffer() is deprecated due to security and usability issues.

I change it to `Buffer.alloc(size)`