### PR TITLE
Fix curl request for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/seishun/node-steam.git"
   },
   "scripts": {
-    "prepare": "curl -fo servers.json 'https://api.steampowered.com/ISteamDirectory/GetCMList/v1/?cellid=0'"
+    "prepare": "curl -fo servers.json \"https://api.steampowered.com/ISteamDirectory/GetCMList/v1/?cellid=0\""
   },
   "dependencies": {
     "adm-zip": "^0.4",


### PR DESCRIPTION
curl URLs must be in double-quotes to work in Windows. Please test this for bash / Linux.