### PR TITLE
Fix: Change CMsgClientServiceMethod to CMsgClientServiceMethodLegacy.

### DIFF
--- a/lib/handlers/unified_messages/index.js
+++ b/lib/handlers/unified_messages/index.js
@@ -26,13 +26,13 @@ SteamUnifiedMessages.prototype.send = function(methodName, body, callback) {
     this._client.send({
       msg: EMsg.ClientServiceMethod,
       proto: {}
-    }, new schema.CMsgClientServiceMethod({
+    }, new schema.CMsgClientServiceMethodLegacy({
       method_name: this._service + '.' + methodName + '#1',
       serialized_method: req.toBuffer(),
       is_notification: !callback
     }).toBuffer(), callback && function(header, body) {
       eresult = header.proto.eresult;
-      var resp = schema.CMsgClientServiceMethodResponse.decode(body);
+      var resp = schema.CMsgClientServiceMethodLegacyResponse.decode(body);
       cb(null, resp.serialized_method_response);
     });
   }.bind(this), body, function(err, res) {


### PR DESCRIPTION
Currently `CMsgClientServiceMethod` is returning me `TypeError: schema.CMsgClientServiceMethod is not a constructor`, so I went after the solution and I didn't find anyone with the same problem.

I decided to look at the list of `schema` and ended up finding that the method `CMsgClientServiceMethod` was changed to `CMsgClientServiceMethodLegacy`, so the code worked correctly

I don't know if that would be the best way to resolve it, but at least it is a temporary way.